### PR TITLE
Upgrade to revit 2025

### DIFF
--- a/DesignAutomationHandler2025/DesignAutomationHandler.addin
+++ b/DesignAutomationHandler2025/DesignAutomationHandler.addin
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<RevitAddIns>
+  <AddIn Type="Command">
+    <Name>DesignAutomationHandler</Name>
+    <Assembly>.\DesignAutomationHandler.dll</Assembly>
+    <AddInId>68C06BDB-E08C-4E27-9CF9-2C6210545F9C</AddInId>
+    <FullClassName>DesignAutomationHandler.DesignAutomationHandlerApp</FullClassName>
+    <Text>DesignAutomationHandler</Text>
+    <VisibilityMode>AlwaysVisible</VisibilityMode>
+    <Description>"DesignAutomationHandler For Local Debugging of D4R"</Description>
+    <VendorId>Autodesk</VendorId>
+    <VendorDescription>Autodesk, www.autodesk.com</VendorDescription>
+  </AddIn>
+</RevitAddIns>

--- a/DesignAutomationHandler2025/DesignAutomationHandler2025.csproj
+++ b/DesignAutomationHandler2025/DesignAutomationHandler2025.csproj
@@ -1,0 +1,73 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>net8.0-windows</TargetFramework>
+		<OutputType>Library</OutputType>
+		<RootNamespace>DesignAutomationHandler</RootNamespace>
+		<AssemblyName>DesignAutomationHandler</AssemblyName>
+		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+		<UseWindowsForms>true</UseWindowsForms>
+		<ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
+		<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+		<Configurations>Debug;Release</Configurations>
+	</PropertyGroup>
+
+	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+		<PlatformTarget>AnyCPU</PlatformTarget>
+		<DebugSymbols>true</DebugSymbols>
+		<DebugType>full</DebugType>
+		<Optimize>false</Optimize>
+		<OutputPath>bin\Debug\</OutputPath>
+		<DefineConstants>DEBUG;TRACE</DefineConstants>
+		<ErrorReport>prompt</ErrorReport>
+		<WarningLevel>4</WarningLevel>
+	</PropertyGroup>
+
+	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+		<PlatformTarget>AnyCPU</PlatformTarget>
+		<DebugType>pdbonly</DebugType>
+		<Optimize>true</Optimize>
+		<OutputPath>bin\Release\</OutputPath>
+		<DefineConstants>TRACE</DefineConstants>
+		<ErrorReport>prompt</ErrorReport>
+		<WarningLevel>4</WarningLevel>
+	</PropertyGroup>
+
+	<!-- .NET CORE Configurations (Revit 2025+) -->
+	<PropertyGroup Condition="!$(TargetFramework.StartsWith('net4'))">
+		<EnableDynamicLoading>true</EnableDynamicLoading>
+		<GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+		<GenerateDependencyFile>false</GenerateDependencyFile>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+		<PackageReference Include="Autodesk.Forge.DesignAutomation.Revit" Version="2025.0.1" />
+		<PackageReference Include="Revit_All_Main_Versions_API_x64" Version="2025.0.0" IncludeAssets="build; compile" PrivateAssets="All" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<Compile Include="..\DesignAutomationHandler.cs" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<Content Include="DesignAutomationHandler.addin">
+			<CopyToOutputDirectory>Never</CopyToOutputDirectory>
+			<SubType>Designer</SubType>
+		</Content>
+	</ItemGroup>
+
+	<PropertyGroup>
+		<PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<None Include="..\LICENSE.txt" Pack="true" PackagePath="$(PackageLicenseFile)" />
+	</ItemGroup>
+
+	<PropertyGroup>
+		<PostBuildEvent>
+			if exist "$(AppData)\Autodesk\REVIT\Addins\2025" copy "$(MSBuildProjectDirectory)\*.addin" "$(AppData)\Autodesk\REVIT\Addins\2025"
+			if exist "$(AppData)\Autodesk\REVIT\Addins\2025" copy "$(MSBuildProjectDirectory)\$(OutputPath)*.dll" "$(AppData)\Autodesk\REVIT\Addins\2025"
+		</PostBuildEvent>
+	</PropertyGroup>
+</Project>

--- a/DesignAutomationHandler2025/Properties/AssemblyInfo.cs
+++ b/DesignAutomationHandler2025/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("DesignAutomationHandler")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("DesignAutomationHandler")]
+[assembly: AssemblyCopyright("Copyright © 2019")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("5B638ACA-9ACE-447B-B323-205C9831A85E")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Platforms](https://img.shields.io/badge/Plugins-Windows-lightgray.svg)
 ![.NET](https://img.shields.io/badge/.NET%20Framework-4.8-blue.svg)
-[![Revit](https://img.shields.io/badge/Revit-2018|2019|2020|2021|2022|2023|2024-lightblue.svg)](http://developer.autodesk.com/)
+[![Revit](https://img.shields.io/badge/Revit-2018|2019|2020|2021|2022|2023|2024|2025-lightblue.svg)](http://developer.autodesk.com/)
 
 # Description
 
@@ -23,10 +23,10 @@ See [step-by-step video](https://www.youtube.com/watch?v=i0LJ9JOpKMQ)
 
 ## Compile and Load on Revit
 
-1. Build the solution `DesignAutomationHandler`, compiling DesignAutomationHandler for Revit 2018 (`DesignAutomationHandler2018`), Revit 2019 (`DesignAutomationHandler2019`), Revit 2020 (`DesignAutomationHandler2020`), Revit 2021 (`DesignAutomationHandler2021`), Revit 2022 (`DesignAutomationHandler2022`), Revit 2023 (`DesignAutomationHandler2023`), and Revit 2024 (`DesignAutomationHandler2024`)
-> Design Automation for Revit currently supports Revit 2018, 2019, 2020, 2021, 2022, 2023, and 2024.
+1. Build the solution `DesignAutomationHandler`, compiling DesignAutomationHandler for Revit 2018 (`DesignAutomationHandler2018`), Revit 2019 (`DesignAutomationHandler2019`), Revit 2020 (`DesignAutomationHandler2020`), Revit 2021 (`DesignAutomationHandler2021`), Revit 2022 (`DesignAutomationHandler2022`), Revit 2023 (`DesignAutomationHandler2023`), and Revit 2024 (`DesignAutomationHandler2024`), and Revit 2025 (`DesignAutomationHandler2025`)
+> Design Automation for Revit currently supports Revit 2018, 2019, 2020, 2021, 2022, 2023, 2024, and 2025.
 
-2. Copy/paste the `DesignAutomationHandler.addin` into the "Addins" folder `C:\ProgramData\Autodesk\Revit\Addins\XXXX\`, where `XXXX` is the Revit version (e.g. 2018, 2019, 2020, 2021, 2022, 2023, 2024) you intend to run.
+2. Copy/paste the `DesignAutomationHandler.addin` into the "Addins" folder `C:\ProgramData\Autodesk\Revit\Addins\XXXX\`, where `XXXX` is the Revit version (e.g. 2018, 2019, 2020, 2021, 2022, 2023, 2024, 2025) you intend to run.
 
 3. Copy/paste the `.addin` file of your Design Automation for Revit plugin into the same folder `C:\ProgramData\Autodesk\Revit\Addins\XXXX\`. 
 


### PR DESCRIPTION
- Add support for Revit 2025:
1. Update .csproj to the SDK style.
2. Use Revit_All_Main_Versions_API_x64 nuget package for RevitAPI.
- Update the README.md file.   